### PR TITLE
Implement repositories and entities for full SQL schema

### DIFF
--- a/src/main/kotlin/com/airline/aeropuerto/Aeropuerto.kt
+++ b/src/main/kotlin/com/airline/aeropuerto/Aeropuerto.kt
@@ -1,0 +1,31 @@
+package com.airline.aeropuerto
+
+import com.airline.ruta.Ruta
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "aeropuertos")
+data class Aeropuerto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "nombre")
+    var nombre: String? = null,
+
+    @Column(name = "ciudad")
+    var ciudad: String? = null,
+
+    @Column(name = "pais")
+    var pais: String? = null,
+
+    @Column(name = "codigo_iata")
+    var codigoIata: String,
+
+    @OneToMany(mappedBy = "origen")
+    var rutasOrigen: MutableList<Ruta> = mutableListOf(),
+
+    @OneToMany(mappedBy = "destino")
+    var rutasDestino: MutableList<Ruta> = mutableListOf()
+)

--- a/src/main/kotlin/com/airline/aeropuerto/AeropuertoRepository.kt
+++ b/src/main/kotlin/com/airline/aeropuerto/AeropuertoRepository.kt
@@ -1,0 +1,7 @@
+package com.airline.aeropuerto
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AeropuertoRepository : JpaRepository<Aeropuerto, Long> {
+    fun findByCodigoIata(codigoIata: String): Aeropuerto?
+}

--- a/src/main/kotlin/com/airline/asiento/Asiento.kt
+++ b/src/main/kotlin/com/airline/asiento/Asiento.kt
@@ -1,0 +1,29 @@
+package com.airline.asiento
+
+import com.airline.avion.Avion
+import com.airline.boleto.Boleto
+import com.airline.claseasiento.ClaseAsiento
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "asientos")
+data class Asiento(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "id_avion")
+    var avion: Avion,
+
+    @Column(name = "numero_asiento")
+    var numeroAsiento: String,
+
+    @ManyToOne
+    @JoinColumn(name = "id_clase")
+    var clase: ClaseAsiento? = null,
+
+    @OneToMany(mappedBy = "asiento")
+    var boletos: MutableList<Boleto> = mutableListOf()
+)

--- a/src/main/kotlin/com/airline/asiento/AsientoRepository.kt
+++ b/src/main/kotlin/com/airline/asiento/AsientoRepository.kt
@@ -1,0 +1,5 @@
+package com.airline.asiento
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AsientoRepository : JpaRepository<Asiento, Long>

--- a/src/main/kotlin/com/airline/avion/Avion.kt
+++ b/src/main/kotlin/com/airline/avion/Avion.kt
@@ -1,24 +1,31 @@
 package com.airline.avion
 
+import com.airline.asiento.Asiento
 import com.airline.vuelo.Vuelo
 import jakarta.persistence.*
 
 @Entity
-@Table(name = "avion")
+@Table(name = "aviones")
 data class Avion(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id_avion")
-    var idAvion: Long? = null,
-
-    @Column(name = "matricula")
-    var matricula: String,
+    @Column(name = "id")
+    var id: Long? = null,
 
     @Column(name = "modelo")
-    var modelo: String,
+    var modelo: String? = null,
 
-    @Column(name = "capacidad")
-    var capacidad: Int,
+    @Column(name = "fabricante")
+    var fabricante: String? = null,
+
+    @Column(name = "capacidad_total")
+    var capacidadTotal: Int? = null,
+
+    @Column(name = "estado")
+    var estado: String? = null,
+
+    @OneToMany(mappedBy = "avion")
+    var asientos: MutableList<Asiento> = mutableListOf(),
 
     @OneToMany(mappedBy = "avion")
     var vuelos: MutableList<Vuelo> = mutableListOf()

--- a/src/main/kotlin/com/airline/avion/AvionRepository.kt
+++ b/src/main/kotlin/com/airline/avion/AvionRepository.kt
@@ -1,0 +1,7 @@
+package com.airline.avion
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AvionRepository : JpaRepository<Avion, Long>

--- a/src/main/kotlin/com/airline/boleto/Boleto.kt
+++ b/src/main/kotlin/com/airline/boleto/Boleto.kt
@@ -1,0 +1,46 @@
+package com.airline.boleto
+
+import com.airline.asiento.Asiento
+import com.airline.pasajero.Pasajero
+import com.airline.pago.Pago
+import com.airline.checkin.Checkin
+import com.airline.vuelo.Vuelo
+import jakarta.persistence.*
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Entity
+@Table(name = "boletos")
+data class Boleto(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "id_vuelo")
+    var vuelo: Vuelo,
+
+    @ManyToOne
+    @JoinColumn(name = "id_pasajero")
+    var pasajero: Pasajero,
+
+    @ManyToOne
+    @JoinColumn(name = "id_asiento")
+    var asiento: Asiento,
+
+    @Column(name = "precio")
+    var precio: BigDecimal? = null,
+
+    @Column(name = "fecha_emision")
+    var fechaEmision: LocalDate? = null,
+
+    @Column(name = "estado")
+    var estado: String? = null,
+
+    @OneToMany(mappedBy = "boleto")
+    var pagos: MutableList<Pago> = mutableListOf(),
+
+    @OneToOne(mappedBy = "boleto")
+    var checkin: Checkin? = null
+)

--- a/src/main/kotlin/com/airline/boleto/BoletoRepository.kt
+++ b/src/main/kotlin/com/airline/boleto/BoletoRepository.kt
@@ -1,0 +1,5 @@
+package com.airline.boleto
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BoletoRepository : JpaRepository<Boleto, Long>

--- a/src/main/kotlin/com/airline/checkin/Checkin.kt
+++ b/src/main/kotlin/com/airline/checkin/Checkin.kt
@@ -1,0 +1,32 @@
+package com.airline.checkin
+
+import com.airline.boleto.Boleto
+import com.airline.equipaje.Equipaje
+import jakarta.persistence.*
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Entity
+@Table(name = "checkin")
+data class Checkin(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @OneToOne
+    @JoinColumn(name = "id_boleto")
+    var boleto: Boleto,
+
+    @Column(name = "fecha_checkin")
+    var fechaCheckin: LocalDate? = null,
+
+    @Column(name = "equipaje_si_no")
+    var equipajeSiNo: Char? = null,
+
+    @Column(name = "peso_equipaje")
+    var pesoEquipaje: BigDecimal? = null,
+
+    @OneToMany(mappedBy = "checkin")
+    var equipajes: MutableList<Equipaje> = mutableListOf()
+)

--- a/src/main/kotlin/com/airline/checkin/CheckinRepository.kt
+++ b/src/main/kotlin/com/airline/checkin/CheckinRepository.kt
@@ -1,0 +1,5 @@
+package com.airline.checkin
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CheckinRepository : JpaRepository<Checkin, Long>

--- a/src/main/kotlin/com/airline/claseasiento/ClaseAsiento.kt
+++ b/src/main/kotlin/com/airline/claseasiento/ClaseAsiento.kt
@@ -1,0 +1,22 @@
+package com.airline.claseasiento
+
+import com.airline.asiento.Asiento
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "clases_asiento")
+data class ClaseAsiento(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "nombre_clase")
+    var nombreClase: String? = null,
+
+    @Column(name = "descripcion")
+    var descripcion: String? = null,
+
+    @OneToMany(mappedBy = "clase")
+    var asientos: MutableList<Asiento> = mutableListOf()
+)

--- a/src/main/kotlin/com/airline/claseasiento/ClaseAsientoRepository.kt
+++ b/src/main/kotlin/com/airline/claseasiento/ClaseAsientoRepository.kt
@@ -1,0 +1,5 @@
+package com.airline.claseasiento
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ClaseAsientoRepository : JpaRepository<ClaseAsiento, Long>

--- a/src/main/kotlin/com/airline/empleado/Empleado.kt
+++ b/src/main/kotlin/com/airline/empleado/Empleado.kt
@@ -1,11 +1,12 @@
-package com.airline.pasajero
+package com.airline.empleado
 
-import com.airline.boleto.Boleto
+import com.airline.turno.TurnoEmpleado
+import com.airline.usuario.Usuario
 import jakarta.persistence.*
 
 @Entity
-@Table(name = "pasajeros")
-data class Pasajero(
+@Table(name = "empleados")
+data class Empleado(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -17,15 +18,18 @@ data class Pasajero(
     @Column(name = "apellidos")
     var apellidos: String? = null,
 
+    @Column(name = "puesto")
+    var puesto: String? = null,
+
     @Column(name = "email")
     var email: String? = null,
 
     @Column(name = "telefono")
     var telefono: String? = null,
 
-    @Column(name = "documento_identidad")
-    var documentoIdentidad: String? = null,
+    @OneToMany(mappedBy = "empleado")
+    var turnos: MutableList<TurnoEmpleado> = mutableListOf(),
 
-    @OneToMany(mappedBy = "pasajero")
-    var boletos: MutableList<Boleto> = mutableListOf()
+    @OneToMany(mappedBy = "empleado")
+    var usuarios: MutableList<Usuario> = mutableListOf()
 )

--- a/src/main/kotlin/com/airline/empleado/EmpleadoRepository.kt
+++ b/src/main/kotlin/com/airline/empleado/EmpleadoRepository.kt
@@ -1,0 +1,5 @@
+package com.airline.empleado
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EmpleadoRepository : JpaRepository<Empleado, Long>

--- a/src/main/kotlin/com/airline/equipaje/Equipaje.kt
+++ b/src/main/kotlin/com/airline/equipaje/Equipaje.kt
@@ -1,0 +1,24 @@
+package com.airline.equipaje
+
+import com.airline.checkin.Checkin
+import jakarta.persistence.*
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "equipaje")
+data class Equipaje(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "id_checkin")
+    var checkin: Checkin,
+
+    @Column(name = "descripcion")
+    var descripcion: String? = null,
+
+    @Column(name = "peso")
+    var peso: BigDecimal? = null
+)

--- a/src/main/kotlin/com/airline/equipaje/EquipajeRepository.kt
+++ b/src/main/kotlin/com/airline/equipaje/EquipajeRepository.kt
@@ -1,0 +1,5 @@
+package com.airline.equipaje
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EquipajeRepository : JpaRepository<Equipaje, Long>

--- a/src/main/kotlin/com/airline/pago/Pago.kt
+++ b/src/main/kotlin/com/airline/pago/Pago.kt
@@ -1,0 +1,28 @@
+package com.airline.pago
+
+import com.airline.boleto.Boleto
+import jakarta.persistence.*
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Entity
+@Table(name = "pagos")
+data class Pago(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "id_boleto")
+    var boleto: Boleto,
+
+    @Column(name = "metodo_pago")
+    var metodoPago: String? = null,
+
+    @Column(name = "monto")
+    var monto: BigDecimal? = null,
+
+    @Column(name = "fecha_pago")
+    var fechaPago: LocalDate? = null
+)

--- a/src/main/kotlin/com/airline/pago/PagoRepository.kt
+++ b/src/main/kotlin/com/airline/pago/PagoRepository.kt
@@ -1,0 +1,5 @@
+package com.airline.pago
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PagoRepository : JpaRepository<Pago, Long>

--- a/src/main/kotlin/com/airline/pasajero/PasajeroRepository.kt
+++ b/src/main/kotlin/com/airline/pasajero/PasajeroRepository.kt
@@ -1,0 +1,7 @@
+package com.airline.pasajero
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PasajeroRepository : JpaRepository<Pasajero, Long>

--- a/src/main/kotlin/com/airline/ruta/Ruta.kt
+++ b/src/main/kotlin/com/airline/ruta/Ruta.kt
@@ -1,21 +1,30 @@
 package com.airline.ruta
 
+import com.airline.aeropuerto.Aeropuerto
 import com.airline.vuelo.Vuelo
 import jakarta.persistence.*
 
 @Entity
-@Table(name = "ruta")
+@Table(name = "rutas")
 data class Ruta(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id_ruta")
-    var idRuta: Long? = null,
+    @Column(name = "id")
+    var id: Long? = null,
 
-    @Column(name = "origen")
-    var origen: String,
+    @ManyToOne
+    @JoinColumn(name = "a_origen_id")
+    var origen: Aeropuerto,
 
-    @Column(name = "destino")
-    var destino: String,
+    @ManyToOne
+    @JoinColumn(name = "a_destino_id")
+    var destino: Aeropuerto,
+
+    @Column(name = "duracion_aprox_min")
+    var duracionAproxMin: Double? = null,
+
+    @Column(name = "distancia_km")
+    var distanciaKm: Double? = null,
 
     @OneToMany(mappedBy = "ruta")
     var vuelos: MutableList<Vuelo> = mutableListOf()

--- a/src/main/kotlin/com/airline/ruta/RutaRepository.kt
+++ b/src/main/kotlin/com/airline/ruta/RutaRepository.kt
@@ -1,0 +1,7 @@
+package com.airline.ruta
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RutaRepository : JpaRepository<Ruta, Long>

--- a/src/main/kotlin/com/airline/turno/TurnoEmpleado.kt
+++ b/src/main/kotlin/com/airline/turno/TurnoEmpleado.kt
@@ -1,0 +1,25 @@
+package com.airline.turno
+
+import com.airline.empleado.Empleado
+import com.airline.vuelo.Vuelo
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "turnos_empleado")
+data class TurnoEmpleado(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "id_empleado")
+    var empleado: Empleado,
+
+    @ManyToOne
+    @JoinColumn(name = "id_vuelo")
+    var vuelo: Vuelo,
+
+    @Column(name = "rol_en_vuelo")
+    var rolEnVuelo: String? = null
+)

--- a/src/main/kotlin/com/airline/turno/TurnoEmpleadoRepository.kt
+++ b/src/main/kotlin/com/airline/turno/TurnoEmpleadoRepository.kt
@@ -1,0 +1,5 @@
+package com.airline.turno
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TurnoEmpleadoRepository : JpaRepository<TurnoEmpleado, Long>

--- a/src/main/kotlin/com/airline/usuario/Usuario.kt
+++ b/src/main/kotlin/com/airline/usuario/Usuario.kt
@@ -1,0 +1,26 @@
+package com.airline.usuario
+
+import com.airline.empleado.Empleado
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "usuarios")
+data class Usuario(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long? = null,
+
+    @Column(name = "username")
+    var username: String,
+
+    @Column(name = "password_hash")
+    var passwordHash: String,
+
+    @Column(name = "rol")
+    var rol: String? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "id_empleado")
+    var empleado: Empleado? = null
+)

--- a/src/main/kotlin/com/airline/usuario/UsuarioRepository.kt
+++ b/src/main/kotlin/com/airline/usuario/UsuarioRepository.kt
@@ -1,0 +1,5 @@
+package com.airline.usuario
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UsuarioRepository : JpaRepository<Usuario, Long>

--- a/src/main/kotlin/com/airline/vuelo/Vuelo.kt
+++ b/src/main/kotlin/com/airline/vuelo/Vuelo.kt
@@ -1,20 +1,19 @@
 package com.airline.vuelo
 
 import com.airline.avion.Avion
+import com.airline.boleto.Boleto
 import com.airline.ruta.Ruta
-import com.airline.pasajero.Pasajero
+import com.airline.turno.TurnoEmpleado
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
-@Table(name = "vuelo")
+@Table(name = "vuelos")
 data class Vuelo(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id_vuelo")
-    var idVuelo: Long? = null,
-
-    @Column(name = "numero_vuelo")
-    var numeroVuelo: String,
+    @Column(name = "id")
+    var id: Long? = null,
 
     @ManyToOne
     @JoinColumn(name = "id_ruta")
@@ -24,6 +23,18 @@ data class Vuelo(
     @JoinColumn(name = "id_avion")
     var avion: Avion,
 
+    @Column(name = "salida_ts")
+    var salidaTs: LocalDateTime? = null,
+
+    @Column(name = "llegada_ts")
+    var llegadaTs: LocalDateTime? = null,
+
+    @Column(name = "estado")
+    var estado: String? = null,
+
     @OneToMany(mappedBy = "vuelo")
-    var pasajeros: MutableList<Pasajero> = mutableListOf()
+    var boletos: MutableList<Boleto> = mutableListOf(),
+
+    @OneToMany(mappedBy = "vuelo")
+    var turnos: MutableList<TurnoEmpleado> = mutableListOf()
 )

--- a/src/main/kotlin/com/airline/vuelo/VueloRepository.kt
+++ b/src/main/kotlin/com/airline/vuelo/VueloRepository.kt
@@ -1,0 +1,7 @@
+package com.airline.vuelo
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface VueloRepository : JpaRepository<Vuelo, Long>


### PR DESCRIPTION
## Summary
- add entity and repository classes for Aeropuerto, ClaseAsiento, Asiento, Boleto, Pago, Empleado, TurnoEmpleado, Checkin, Equipaje and Usuario
- update existing domain models to reflect full database schema

## Testing
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68be78447fb8832da10c0882f17edd02