### PR TITLE
Add service layer with seat validation

### DIFF
--- a/src/main/kotlin/com/airline/aeropuerto/AeropuertoService.kt
+++ b/src/main/kotlin/com/airline/aeropuerto/AeropuertoService.kt
@@ -1,0 +1,29 @@
+package com.airline.aeropuerto
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class AeropuertoService(private val aeropuertoRepository: AeropuertoRepository) {
+    fun findAll(): List<Aeropuerto> = aeropuertoRepository.findAll()
+
+    fun findById(id: Long): Aeropuerto =
+        aeropuertoRepository.findById(id).orElseThrow { NotFoundException("Aeropuerto $id no encontrado") }
+
+    fun create(aeropuerto: Aeropuerto): Aeropuerto = aeropuertoRepository.save(aeropuerto)
+
+    fun update(id: Long, aeropuerto: Aeropuerto): Aeropuerto {
+        if (!aeropuertoRepository.existsById(id)) {
+            throw NotFoundException("Aeropuerto $id no encontrado")
+        }
+        aeropuerto.id = id
+        return aeropuertoRepository.save(aeropuerto)
+    }
+
+    fun delete(id: Long) {
+        if (!aeropuertoRepository.existsById(id)) {
+            throw NotFoundException("Aeropuerto $id no encontrado")
+        }
+        aeropuertoRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/asiento/AsientoService.kt
+++ b/src/main/kotlin/com/airline/asiento/AsientoService.kt
@@ -1,0 +1,29 @@
+package com.airline.asiento
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class AsientoService(private val asientoRepository: AsientoRepository) {
+    fun findAll(): List<Asiento> = asientoRepository.findAll()
+
+    fun findById(id: Long): Asiento =
+        asientoRepository.findById(id).orElseThrow { NotFoundException("Asiento $id no encontrado") }
+
+    fun create(asiento: Asiento): Asiento = asientoRepository.save(asiento)
+
+    fun update(id: Long, asiento: Asiento): Asiento {
+        if (!asientoRepository.existsById(id)) {
+            throw NotFoundException("Asiento $id no encontrado")
+        }
+        asiento.id = id
+        return asientoRepository.save(asiento)
+    }
+
+    fun delete(id: Long) {
+        if (!asientoRepository.existsById(id)) {
+            throw NotFoundException("Asiento $id no encontrado")
+        }
+        asientoRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/avion/AvionService.kt
+++ b/src/main/kotlin/com/airline/avion/AvionService.kt
@@ -1,0 +1,29 @@
+package com.airline.avion
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class AvionService(private val avionRepository: AvionRepository) {
+    fun findAll(): List<Avion> = avionRepository.findAll()
+
+    fun findById(id: Long): Avion =
+        avionRepository.findById(id).orElseThrow { NotFoundException("Avion $id no encontrado") }
+
+    fun create(avion: Avion): Avion = avionRepository.save(avion)
+
+    fun update(id: Long, avion: Avion): Avion {
+        if (!avionRepository.existsById(id)) {
+            throw NotFoundException("Avion $id no encontrado")
+        }
+        avion.id = id
+        return avionRepository.save(avion)
+    }
+
+    fun delete(id: Long) {
+        if (!avionRepository.existsById(id)) {
+            throw NotFoundException("Avion $id no encontrado")
+        }
+        avionRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/boleto/BoletoRepository.kt
+++ b/src/main/kotlin/com/airline/boleto/BoletoRepository.kt
@@ -2,4 +2,6 @@ package com.airline.boleto
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface BoletoRepository : JpaRepository<Boleto, Long>
+interface BoletoRepository : JpaRepository<Boleto, Long> {
+    fun existsByVueloIdAndAsientoId(vueloId: Long?, asientoId: Long?): Boolean
+}

--- a/src/main/kotlin/com/airline/boleto/BoletoService.kt
+++ b/src/main/kotlin/com/airline/boleto/BoletoService.kt
@@ -1,0 +1,38 @@
+package com.airline.boleto
+
+import com.airline.exception.BusinessException
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class BoletoService(private val boletoRepository: BoletoRepository) {
+    fun findAll(): List<Boleto> = boletoRepository.findAll()
+
+    fun findById(id: Long): Boleto =
+        boletoRepository.findById(id).orElseThrow { NotFoundException("Boleto $id no encontrado") }
+
+    fun create(boleto: Boleto): Boleto {
+        if (boletoRepository.existsByVueloIdAndAsientoId(boleto.vuelo.id, boleto.asiento.id)) {
+            throw BusinessException("El asiento ya está vendido para este vuelo")
+        }
+        return boletoRepository.save(boleto)
+    }
+
+    fun update(id: Long, boleto: Boleto): Boleto {
+        val existing = findById(id)
+        if (boleto.vuelo.id != existing.vuelo.id || boleto.asiento.id != existing.asiento.id) {
+            if (boletoRepository.existsByVueloIdAndAsientoId(boleto.vuelo.id, boleto.asiento.id)) {
+                throw BusinessException("El asiento ya está vendido para este vuelo")
+            }
+        }
+        boleto.id = id
+        return boletoRepository.save(boleto)
+    }
+
+    fun delete(id: Long) {
+        if (!boletoRepository.existsById(id)) {
+            throw NotFoundException("Boleto $id no encontrado")
+        }
+        boletoRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/checkin/CheckinService.kt
+++ b/src/main/kotlin/com/airline/checkin/CheckinService.kt
@@ -1,0 +1,29 @@
+package com.airline.checkin
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class CheckinService(private val checkinRepository: CheckinRepository) {
+    fun findAll(): List<Checkin> = checkinRepository.findAll()
+
+    fun findById(id: Long): Checkin =
+        checkinRepository.findById(id).orElseThrow { NotFoundException("Checkin $id no encontrado") }
+
+    fun create(checkin: Checkin): Checkin = checkinRepository.save(checkin)
+
+    fun update(id: Long, checkin: Checkin): Checkin {
+        if (!checkinRepository.existsById(id)) {
+            throw NotFoundException("Checkin $id no encontrado")
+        }
+        checkin.id = id
+        return checkinRepository.save(checkin)
+    }
+
+    fun delete(id: Long) {
+        if (!checkinRepository.existsById(id)) {
+            throw NotFoundException("Checkin $id no encontrado")
+        }
+        checkinRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/claseasiento/ClaseAsientoService.kt
+++ b/src/main/kotlin/com/airline/claseasiento/ClaseAsientoService.kt
@@ -1,0 +1,29 @@
+package com.airline.claseasiento
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class ClaseAsientoService(private val claseAsientoRepository: ClaseAsientoRepository) {
+    fun findAll(): List<ClaseAsiento> = claseAsientoRepository.findAll()
+
+    fun findById(id: Long): ClaseAsiento =
+        claseAsientoRepository.findById(id).orElseThrow { NotFoundException("ClaseAsiento $id no encontrado") }
+
+    fun create(clase: ClaseAsiento): ClaseAsiento = claseAsientoRepository.save(clase)
+
+    fun update(id: Long, clase: ClaseAsiento): ClaseAsiento {
+        if (!claseAsientoRepository.existsById(id)) {
+            throw NotFoundException("ClaseAsiento $id no encontrado")
+        }
+        clase.id = id
+        return claseAsientoRepository.save(clase)
+    }
+
+    fun delete(id: Long) {
+        if (!claseAsientoRepository.existsById(id)) {
+            throw NotFoundException("ClaseAsiento $id no encontrado")
+        }
+        claseAsientoRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/empleado/EmpleadoService.kt
+++ b/src/main/kotlin/com/airline/empleado/EmpleadoService.kt
@@ -1,0 +1,29 @@
+package com.airline.empleado
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class EmpleadoService(private val empleadoRepository: EmpleadoRepository) {
+    fun findAll(): List<Empleado> = empleadoRepository.findAll()
+
+    fun findById(id: Long): Empleado =
+        empleadoRepository.findById(id).orElseThrow { NotFoundException("Empleado $id no encontrado") }
+
+    fun create(empleado: Empleado): Empleado = empleadoRepository.save(empleado)
+
+    fun update(id: Long, empleado: Empleado): Empleado {
+        if (!empleadoRepository.existsById(id)) {
+            throw NotFoundException("Empleado $id no encontrado")
+        }
+        empleado.id = id
+        return empleadoRepository.save(empleado)
+    }
+
+    fun delete(id: Long) {
+        if (!empleadoRepository.existsById(id)) {
+            throw NotFoundException("Empleado $id no encontrado")
+        }
+        empleadoRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/equipaje/EquipajeService.kt
+++ b/src/main/kotlin/com/airline/equipaje/EquipajeService.kt
@@ -1,0 +1,29 @@
+package com.airline.equipaje
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class EquipajeService(private val equipajeRepository: EquipajeRepository) {
+    fun findAll(): List<Equipaje> = equipajeRepository.findAll()
+
+    fun findById(id: Long): Equipaje =
+        equipajeRepository.findById(id).orElseThrow { NotFoundException("Equipaje $id no encontrado") }
+
+    fun create(equipaje: Equipaje): Equipaje = equipajeRepository.save(equipaje)
+
+    fun update(id: Long, equipaje: Equipaje): Equipaje {
+        if (!equipajeRepository.existsById(id)) {
+            throw NotFoundException("Equipaje $id no encontrado")
+        }
+        equipaje.id = id
+        return equipajeRepository.save(equipaje)
+    }
+
+    fun delete(id: Long) {
+        if (!equipajeRepository.existsById(id)) {
+            throw NotFoundException("Equipaje $id no encontrado")
+        }
+        equipajeRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/exception/BusinessException.kt
+++ b/src/main/kotlin/com/airline/exception/BusinessException.kt
@@ -1,0 +1,3 @@
+package com.airline.exception
+
+class BusinessException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/airline/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/airline/exception/NotFoundException.kt
@@ -1,0 +1,3 @@
+package com.airline.exception
+
+class NotFoundException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/airline/pago/PagoService.kt
+++ b/src/main/kotlin/com/airline/pago/PagoService.kt
@@ -1,0 +1,29 @@
+package com.airline.pago
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class PagoService(private val pagoRepository: PagoRepository) {
+    fun findAll(): List<Pago> = pagoRepository.findAll()
+
+    fun findById(id: Long): Pago =
+        pagoRepository.findById(id).orElseThrow { NotFoundException("Pago $id no encontrado") }
+
+    fun create(pago: Pago): Pago = pagoRepository.save(pago)
+
+    fun update(id: Long, pago: Pago): Pago {
+        if (!pagoRepository.existsById(id)) {
+            throw NotFoundException("Pago $id no encontrado")
+        }
+        pago.id = id
+        return pagoRepository.save(pago)
+    }
+
+    fun delete(id: Long) {
+        if (!pagoRepository.existsById(id)) {
+            throw NotFoundException("Pago $id no encontrado")
+        }
+        pagoRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/pasajero/PasajeroService.kt
+++ b/src/main/kotlin/com/airline/pasajero/PasajeroService.kt
@@ -1,0 +1,29 @@
+package com.airline.pasajero
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class PasajeroService(private val pasajeroRepository: PasajeroRepository) {
+    fun findAll(): List<Pasajero> = pasajeroRepository.findAll()
+
+    fun findById(id: Long): Pasajero =
+        pasajeroRepository.findById(id).orElseThrow { NotFoundException("Pasajero $id no encontrado") }
+
+    fun create(pasajero: Pasajero): Pasajero = pasajeroRepository.save(pasajero)
+
+    fun update(id: Long, pasajero: Pasajero): Pasajero {
+        if (!pasajeroRepository.existsById(id)) {
+            throw NotFoundException("Pasajero $id no encontrado")
+        }
+        pasajero.id = id
+        return pasajeroRepository.save(pasajero)
+    }
+
+    fun delete(id: Long) {
+        if (!pasajeroRepository.existsById(id)) {
+            throw NotFoundException("Pasajero $id no encontrado")
+        }
+        pasajeroRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/ruta/RutaService.kt
+++ b/src/main/kotlin/com/airline/ruta/RutaService.kt
@@ -1,0 +1,29 @@
+package com.airline.ruta
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class RutaService(private val rutaRepository: RutaRepository) {
+    fun findAll(): List<Ruta> = rutaRepository.findAll()
+
+    fun findById(id: Long): Ruta =
+        rutaRepository.findById(id).orElseThrow { NotFoundException("Ruta $id no encontrada") }
+
+    fun create(ruta: Ruta): Ruta = rutaRepository.save(ruta)
+
+    fun update(id: Long, ruta: Ruta): Ruta {
+        if (!rutaRepository.existsById(id)) {
+            throw NotFoundException("Ruta $id no encontrada")
+        }
+        ruta.id = id
+        return rutaRepository.save(ruta)
+    }
+
+    fun delete(id: Long) {
+        if (!rutaRepository.existsById(id)) {
+            throw NotFoundException("Ruta $id no encontrada")
+        }
+        rutaRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/turno/TurnoEmpleadoService.kt
+++ b/src/main/kotlin/com/airline/turno/TurnoEmpleadoService.kt
@@ -1,0 +1,29 @@
+package com.airline.turno
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class TurnoEmpleadoService(private val turnoEmpleadoRepository: TurnoEmpleadoRepository) {
+    fun findAll(): List<TurnoEmpleado> = turnoEmpleadoRepository.findAll()
+
+    fun findById(id: Long): TurnoEmpleado =
+        turnoEmpleadoRepository.findById(id).orElseThrow { NotFoundException("TurnoEmpleado $id no encontrado") }
+
+    fun create(turno: TurnoEmpleado): TurnoEmpleado = turnoEmpleadoRepository.save(turno)
+
+    fun update(id: Long, turno: TurnoEmpleado): TurnoEmpleado {
+        if (!turnoEmpleadoRepository.existsById(id)) {
+            throw NotFoundException("TurnoEmpleado $id no encontrado")
+        }
+        turno.id = id
+        return turnoEmpleadoRepository.save(turno)
+    }
+
+    fun delete(id: Long) {
+        if (!turnoEmpleadoRepository.existsById(id)) {
+            throw NotFoundException("TurnoEmpleado $id no encontrado")
+        }
+        turnoEmpleadoRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/usuario/UsuarioService.kt
+++ b/src/main/kotlin/com/airline/usuario/UsuarioService.kt
@@ -1,0 +1,29 @@
+package com.airline.usuario
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class UsuarioService(private val usuarioRepository: UsuarioRepository) {
+    fun findAll(): List<Usuario> = usuarioRepository.findAll()
+
+    fun findById(id: Long): Usuario =
+        usuarioRepository.findById(id).orElseThrow { NotFoundException("Usuario $id no encontrado") }
+
+    fun create(usuario: Usuario): Usuario = usuarioRepository.save(usuario)
+
+    fun update(id: Long, usuario: Usuario): Usuario {
+        if (!usuarioRepository.existsById(id)) {
+            throw NotFoundException("Usuario $id no encontrado")
+        }
+        usuario.id = id
+        return usuarioRepository.save(usuario)
+    }
+
+    fun delete(id: Long) {
+        if (!usuarioRepository.existsById(id)) {
+            throw NotFoundException("Usuario $id no encontrado")
+        }
+        usuarioRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/airline/vuelo/VueloService.kt
+++ b/src/main/kotlin/com/airline/vuelo/VueloService.kt
@@ -1,0 +1,29 @@
+package com.airline.vuelo
+
+import com.airline.exception.NotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class VueloService(private val vueloRepository: VueloRepository) {
+    fun findAll(): List<Vuelo> = vueloRepository.findAll()
+
+    fun findById(id: Long): Vuelo =
+        vueloRepository.findById(id).orElseThrow { NotFoundException("Vuelo $id no encontrado") }
+
+    fun create(vuelo: Vuelo): Vuelo = vueloRepository.save(vuelo)
+
+    fun update(id: Long, vuelo: Vuelo): Vuelo {
+        if (!vueloRepository.existsById(id)) {
+            throw NotFoundException("Vuelo $id no encontrado")
+        }
+        vuelo.id = id
+        return vueloRepository.save(vuelo)
+    }
+
+    fun delete(id: Long) {
+        if (!vueloRepository.existsById(id)) {
+            throw NotFoundException("Vuelo $id no encontrado")
+        }
+        vueloRepository.deleteById(id)
+    }
+}


### PR DESCRIPTION
## Summary
- add Service classes for all domain entities with CRUD operations
- implement custom NotFoundException and BusinessException
- prevent selling the same seat twice when creating or updating tickets

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68bf89057614832db0d9539db3587400