### PR TITLE
Add REST controllers and DTO mapping for avion, ruta, and vuelo

### DIFF
--- a/src/main/kotlin/com/airline/avion/AvionController.kt
+++ b/src/main/kotlin/com/airline/avion/AvionController.kt
@@ -1,0 +1,42 @@
+package com.airline.avion
+
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/aviones")
+class AvionController(private val avionService: AvionService) {
+
+    @GetMapping
+    fun findAll(): List<AvionDTO> = avionService.findAll().map { it.toDTO() }
+
+    @GetMapping("/{id}")
+    fun findById(@PathVariable id: Long): AvionDTO = avionService.findById(id).toDTO()
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@Valid @RequestBody avionDTO: AvionDTO): AvionDTO =
+        avionService.create(avionDTO.toEntity()).toDTO()
+
+    @PutMapping("/{id}")
+    fun update(
+        @PathVariable id: Long,
+        @Valid @RequestBody avionDTO: AvionDTO
+    ): AvionDTO = avionService.update(id, avionDTO.toEntity()).toDTO()
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable id: Long) = avionService.delete(id)
+
+    // Mapping helpers
+    private fun Avion.toDTO() = AvionDTO(id, modelo ?: "", fabricante ?: "", capacidadTotal ?: 0, estado ?: "")
+
+    private fun AvionDTO.toEntity() = Avion(
+        id = id,
+        modelo = modelo,
+        fabricante = fabricante,
+        capacidadTotal = capacidadTotal,
+        estado = estado
+    )
+}

--- a/src/main/kotlin/com/airline/avion/AvionDTO.kt
+++ b/src/main/kotlin/com/airline/avion/AvionDTO.kt
@@ -1,0 +1,19 @@
+package com.airline.avion
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+/**
+ * DTO for Avion entity.
+ */
+data class AvionDTO(
+    val id: Long? = null,
+    @field:NotBlank
+    val modelo: String,
+    @field:NotBlank
+    val fabricante: String,
+    @field:NotNull
+    val capacidadTotal: Int,
+    @field:NotBlank
+    val estado: String
+)

--- a/src/main/kotlin/com/airline/ruta/RutaController.kt
+++ b/src/main/kotlin/com/airline/ruta/RutaController.kt
@@ -1,0 +1,51 @@
+package com.airline.ruta
+
+import com.airline.aeropuerto.AeropuertoService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/rutas")
+class RutaController(
+    private val rutaService: RutaService,
+    private val aeropuertoService: AeropuertoService
+) {
+    @GetMapping
+    fun findAll(): List<RutaDTO> = rutaService.findAll().map { it.toDTO() }
+
+    @GetMapping("/{id}")
+    fun findById(@PathVariable id: Long): RutaDTO = rutaService.findById(id).toDTO()
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@Valid @RequestBody dto: RutaDTO): RutaDTO =
+        rutaService.create(dto.toEntity()).toDTO()
+
+    @PutMapping("/{id}")
+    fun update(
+        @PathVariable id: Long,
+        @Valid @RequestBody dto: RutaDTO
+    ): RutaDTO = rutaService.update(id, dto.toEntity()).toDTO()
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable id: Long) = rutaService.delete(id)
+
+    // Mapping helpers
+    private fun Ruta.toDTO() = RutaDTO(
+        id = id,
+        origenId = origen.id!!,
+        destinoId = destino.id!!,
+        duracionAproxMin = duracionAproxMin ?: 0.0,
+        distanciaKm = distanciaKm ?: 0.0
+    )
+
+    private fun RutaDTO.toEntity() = Ruta(
+        id = id,
+        origen = aeropuertoService.findById(origenId),
+        destino = aeropuertoService.findById(destinoId),
+        duracionAproxMin = duracionAproxMin,
+        distanciaKm = distanciaKm
+    )
+}

--- a/src/main/kotlin/com/airline/ruta/RutaDTO.kt
+++ b/src/main/kotlin/com/airline/ruta/RutaDTO.kt
@@ -1,0 +1,18 @@
+package com.airline.ruta
+
+import jakarta.validation.constraints.NotNull
+
+/**
+ * DTO for Ruta entity.
+ */
+data class RutaDTO(
+    val id: Long? = null,
+    @field:NotNull
+    val origenId: Long,
+    @field:NotNull
+    val destinoId: Long,
+    @field:NotNull
+    val duracionAproxMin: Double,
+    @field:NotNull
+    val distanciaKm: Double
+)

--- a/src/main/kotlin/com/airline/vuelo/VueloController.kt
+++ b/src/main/kotlin/com/airline/vuelo/VueloController.kt
@@ -1,0 +1,55 @@
+package com.airline.vuelo
+
+import com.airline.avion.AvionService
+import com.airline.ruta.RutaService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/vuelos")
+class VueloController(
+    private val vueloService: VueloService,
+    private val rutaService: RutaService,
+    private val avionService: AvionService
+) {
+    @GetMapping
+    fun findAll(): List<VueloDTO> = vueloService.findAll().map { it.toDTO() }
+
+    @GetMapping("/{id}")
+    fun findById(@PathVariable id: Long): VueloDTO = vueloService.findById(id).toDTO()
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@Valid @RequestBody dto: VueloDTO): VueloDTO =
+        vueloService.create(dto.toEntity()).toDTO()
+
+    @PutMapping("/{id}")
+    fun update(
+        @PathVariable id: Long,
+        @Valid @RequestBody dto: VueloDTO
+    ): VueloDTO = vueloService.update(id, dto.toEntity()).toDTO()
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable id: Long) = vueloService.delete(id)
+
+    // Mapping helpers
+    private fun Vuelo.toDTO() = VueloDTO(
+        id = id,
+        rutaId = ruta.id!!,
+        avionId = avion.id!!,
+        salidaTs = salidaTs ?: java.time.LocalDateTime.MIN,
+        llegadaTs = llegadaTs ?: java.time.LocalDateTime.MIN,
+        estado = estado ?: ""
+    )
+
+    private fun VueloDTO.toEntity() = Vuelo(
+        id = id,
+        ruta = rutaService.findById(rutaId),
+        avion = avionService.findById(avionId),
+        salidaTs = salidaTs,
+        llegadaTs = llegadaTs,
+        estado = estado
+    )
+}

--- a/src/main/kotlin/com/airline/vuelo/VueloDTO.kt
+++ b/src/main/kotlin/com/airline/vuelo/VueloDTO.kt
@@ -1,0 +1,22 @@
+package com.airline.vuelo
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDateTime
+
+/**
+ * DTO for Vuelo entity.
+ */
+data class VueloDTO(
+    val id: Long? = null,
+    @field:NotNull
+    val rutaId: Long,
+    @field:NotNull
+    val avionId: Long,
+    @field:NotNull
+    val salidaTs: LocalDateTime,
+    @field:NotNull
+    val llegadaTs: LocalDateTime,
+    @field:NotBlank
+    val estado: String
+)


### PR DESCRIPTION
## Summary
- add avion REST controller and DTO with validation and CRUD endpoints
- implement ruta controller and DTO mapping Aeropuerto references
- expose vuelo controller with DTO mapping for avion and ruta

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68bf8c542d10832d812052fdc3388e05