### PR TITLE
Add Asiento REST controller with DTO mapping

### DIFF
--- a/src/main/kotlin/com/airline/asiento/AsientoController.kt
+++ b/src/main/kotlin/com/airline/asiento/AsientoController.kt
@@ -1,0 +1,57 @@
+package com.airline.asiento
+
+import com.airline.avion.AvionService
+import com.airline.claseasiento.ClaseAsientoService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/asientos")
+class AsientoController(
+    private val asientoService: AsientoService,
+    private val avionService: AvionService,
+    private val claseAsientoService: ClaseAsientoService,
+) {
+    @GetMapping
+    fun getAll(): List<AsientoDTO> =
+        asientoService.findAll().map { it.toDTO() }
+
+    @GetMapping("/{id}")
+    fun getById(@PathVariable id: Long): AsientoDTO =
+        asientoService.findById(id).toDTO()
+
+    @PostMapping
+    fun create(@Valid @RequestBody dto: AsientoDTO): ResponseEntity<AsientoDTO> {
+        val avion = avionService.findById(dto.avionId)
+        val clase = dto.claseId?.let { claseAsientoService.findById(it) }
+        val created = asientoService.create(dto.toEntity(avion, clase))
+        return ResponseEntity.status(HttpStatus.CREATED).body(created.toDTO())
+    }
+
+    @PutMapping("/{id}")
+    fun update(
+        @PathVariable id: Long,
+        @Valid @RequestBody dto: AsientoDTO,
+    ): ResponseEntity<Void> {
+        val avion = avionService.findById(dto.avionId)
+        val clase = dto.claseId?.let { claseAsientoService.findById(it) }
+        asientoService.update(id, dto.toEntity(avion, clase))
+        return ResponseEntity.noContent().build()
+    }
+
+    @DeleteMapping("/{id}")
+    fun delete(@PathVariable id: Long): ResponseEntity<Void> {
+        asientoService.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+}
+

--- a/src/main/kotlin/com/airline/asiento/AsientoDTO.kt
+++ b/src/main/kotlin/com/airline/asiento/AsientoDTO.kt
@@ -1,0 +1,33 @@
+package com.airline.asiento
+
+import com.airline.avion.Avion
+import com.airline.claseasiento.ClaseAsiento
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+/**
+ * Data Transfer Object for [Asiento].
+ */
+data class AsientoDTO(
+    val id: Long? = null,
+    @field:NotNull val avionId: Long,
+    @field:NotBlank val numeroAsiento: String,
+    val claseId: Long? = null,
+)
+
+fun Asiento.toDTO(): AsientoDTO =
+    AsientoDTO(
+        id = id,
+        avionId = avion.id!!,
+        numeroAsiento = numeroAsiento,
+        claseId = clase?.id,
+    )
+
+fun AsientoDTO.toEntity(avion: Avion, clase: ClaseAsiento?): Asiento =
+    Asiento(
+        id = id,
+        avion = avion,
+        numeroAsiento = numeroAsiento,
+        clase = clase,
+    )
+


### PR DESCRIPTION
## Summary
- Implement REST controller for `/asientos` covering listing, creation, update, and deletion.
- Introduce `AsientoDTO` with validation and mapping helpers to convert to and from entities.
- Return proper HTTP statuses for creation and destructive operations.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68bf8f31442c832d9fcdda8a87985643