### PR TITLE
Add ClaseAsiento controller with CRUD endpoints

### DIFF
--- a/src/main/kotlin/com/airline/claseasiento/ClaseAsientoController.kt
+++ b/src/main/kotlin/com/airline/claseasiento/ClaseAsientoController.kt
@@ -1,0 +1,66 @@
+package com.airline.claseasiento
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/clases-asiento")
+class ClaseAsientoController(private val claseAsientoService: ClaseAsientoService) {
+
+    @GetMapping
+    fun getAll(): List<ClaseAsientoResponse> =
+        claseAsientoService.findAll().map { it.toResponse() }
+
+    @GetMapping("/{id}")
+    fun getById(@PathVariable id: Long): ClaseAsientoResponse =
+        claseAsientoService.findById(id).toResponse()
+
+    @PostMapping
+    fun create(@Valid @RequestBody request: ClaseAsientoRequest): ResponseEntity<ClaseAsientoResponse> {
+        val created = claseAsientoService.create(request.toEntity())
+        return ResponseEntity.status(HttpStatus.CREATED).body(created.toResponse())
+    }
+
+    @PutMapping("/{id}")
+    fun update(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: ClaseAsientoRequest
+    ): ClaseAsientoResponse {
+        val updated = claseAsientoService.update(id, request.toEntity())
+        return updated.toResponse()
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable id: Long) {
+        claseAsientoService.delete(id)
+    }
+}
+
+data class ClaseAsientoRequest(
+    @field:NotBlank val nombreClase: String,
+    @field:NotBlank val descripcion: String
+)
+
+data class ClaseAsientoResponse(
+    val id: Long?,
+    val nombreClase: String?,
+    val descripcion: String?
+)
+
+private fun ClaseAsiento.toResponse() =
+    ClaseAsientoResponse(
+        id = this.id,
+        nombreClase = this.nombreClase,
+        descripcion = this.descripcion
+    )
+
+private fun ClaseAsientoRequest.toEntity() =
+    ClaseAsiento(
+        nombreClase = this.nombreClase,
+        descripcion = this.descripcion
+    )
+


### PR DESCRIPTION
## Summary
- add REST controller for ClaseAsiento with DTO mapping and validation
- expose full CRUD endpoints for `/clases-asiento`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68bf8f329b68832da97ec1167893c3d9