### PR TITLE
Add passenger DTO and controller

### DIFF
--- a/src/main/kotlin/com/airline/pasajero/PasajeroController.kt
+++ b/src/main/kotlin/com/airline/pasajero/PasajeroController.kt
@@ -1,0 +1,42 @@
+package com.airline.pasajero
+
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/pasajeros")
+class PasajeroController(private val pasajeroService: PasajeroService) {
+
+    @GetMapping
+    fun getAll(): List<PasajeroDTO> = pasajeroService.findAll().map { it.toDTO() }
+
+    @GetMapping("/{id}")
+    fun getById(@PathVariable id: Long): PasajeroDTO = pasajeroService.findById(id).toDTO()
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@Valid @RequestBody pasajeroDTO: PasajeroDTO): PasajeroDTO =
+        pasajeroService.create(pasajeroDTO.toEntity()).toDTO()
+
+    @PutMapping("/{id}")
+    fun update(
+        @PathVariable id: Long,
+        @Valid @RequestBody pasajeroDTO: PasajeroDTO,
+    ): PasajeroDTO = pasajeroService.update(id, pasajeroDTO.toEntity()).toDTO()
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable id: Long) {
+        pasajeroService.delete(id)
+    }
+}
+

--- a/src/main/kotlin/com/airline/pasajero/PasajeroDTO.kt
+++ b/src/main/kotlin/com/airline/pasajero/PasajeroDTO.kt
@@ -1,0 +1,47 @@
+package com.airline.pasajero
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * Data Transfer Object for [Pasajero].
+ */
+data class PasajeroDTO(
+    val id: Long? = null,
+    @field:NotBlank(message = "El nombre no puede estar vacío")
+    val nombres: String,
+    @field:NotBlank(message = "El apellido no puede estar vacío")
+    val apellidos: String,
+    @field:NotBlank(message = "El email no puede estar vacío")
+    @field:Email(message = "El email debe tener un formato válido")
+    val email: String,
+    @field:NotBlank(message = "El teléfono no puede estar vacío")
+    val telefono: String,
+    @field:NotBlank(message = "El documento de identidad no puede estar vacío")
+    val documentoIdentidad: String,
+)
+
+/**
+ * Extension function to convert a [Pasajero] entity to a [PasajeroDTO].
+ */
+fun Pasajero.toDTO() = PasajeroDTO(
+    id = id,
+    nombres = nombres ?: "",
+    apellidos = apellidos ?: "",
+    email = email ?: "",
+    telefono = telefono ?: "",
+    documentoIdentidad = documentoIdentidad ?: "",
+)
+
+/**
+ * Extension function to convert a [PasajeroDTO] to a [Pasajero] entity.
+ */
+fun PasajeroDTO.toEntity() = Pasajero(
+    id = id,
+    nombres = nombres,
+    apellidos = apellidos,
+    email = email,
+    telefono = telefono,
+    documentoIdentidad = documentoIdentidad,
+)
+


### PR DESCRIPTION
## Summary
- add PasajeroDTO with validation annotations and mapping helpers
- introduce PasajeroController exposing CRUD endpoints under `/pasajeros`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68bf8f3771ac832db70165aaa69b7e2b