### PR TITLE
Add ticket controller with DTO mapping and validation

### DIFF
--- a/src/main/kotlin/com/airline/boleto/BoletoController.kt
+++ b/src/main/kotlin/com/airline/boleto/BoletoController.kt
@@ -1,0 +1,48 @@
+package com.airline.boleto
+
+import com.airline.asiento.AsientoService
+import com.airline.pasajero.PasajeroService
+import com.airline.vuelo.VueloService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/boletos")
+class BoletoController(
+    private val boletoService: BoletoService,
+    private val vueloService: VueloService,
+    private val pasajeroService: PasajeroService,
+    private val asientoService: AsientoService,
+) {
+    @GetMapping
+    fun getAll(): List<BoletoDTO> = boletoService.findAll().map { it.toDTO() }
+
+    @GetMapping("/{id}")
+    fun getById(@PathVariable id: Long): BoletoDTO = boletoService.findById(id).toDTO()
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@Valid @RequestBody dto: BoletoDTO): BoletoDTO {
+        val vuelo = vueloService.findById(dto.vueloId!!)
+        val pasajero = pasajeroService.findById(dto.pasajeroId!!)
+        val asiento = asientoService.findById(dto.asientoId!!)
+        val saved = boletoService.create(dto.toEntity(vuelo, pasajero, asiento))
+        return saved.toDTO()
+    }
+
+    @PutMapping("/{id}")
+    fun update(@PathVariable id: Long, @Valid @RequestBody dto: BoletoDTO): BoletoDTO {
+        val vuelo = vueloService.findById(dto.vueloId!!)
+        val pasajero = pasajeroService.findById(dto.pasajeroId!!)
+        val asiento = asientoService.findById(dto.asientoId!!)
+        val updated = boletoService.update(id, dto.toEntity(vuelo, pasajero, asiento))
+        return updated.toDTO()
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun delete(@PathVariable id: Long) {
+        boletoService.delete(id)
+    }
+}

--- a/src/main/kotlin/com/airline/boleto/BoletoDTO.kt
+++ b/src/main/kotlin/com/airline/boleto/BoletoDTO.kt
@@ -1,0 +1,43 @@
+package com.airline.boleto
+
+import com.airline.asiento.Asiento
+import com.airline.pasajero.Pasajero
+import com.airline.vuelo.Vuelo
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Data transfer object for [Boleto].
+ */
+data class BoletoDTO(
+    val id: Long? = null,
+    @field:NotNull val vueloId: Long? = null,
+    @field:NotNull val pasajeroId: Long? = null,
+    @field:NotNull val asientoId: Long? = null,
+    @field:NotNull @field:DecimalMin("0.0", inclusive = false) val precio: BigDecimal? = null,
+    @field:NotNull val fechaEmision: LocalDate? = null,
+    @field:NotBlank val estado: String? = null,
+)
+
+fun Boleto.toDTO() = BoletoDTO(
+    id = id,
+    vueloId = vuelo.id,
+    pasajeroId = pasajero.id,
+    asientoId = asiento.id,
+    precio = precio,
+    fechaEmision = fechaEmision,
+    estado = estado
+)
+
+fun BoletoDTO.toEntity(vuelo: Vuelo, pasajero: Pasajero, asiento: Asiento) = Boleto(
+    id = id,
+    vuelo = vuelo,
+    pasajero = pasajero,
+    asiento = asiento,
+    precio = precio,
+    fechaEmision = fechaEmision,
+    estado = estado
+)

--- a/src/main/kotlin/com/airline/exception/BusinessException.kt
+++ b/src/main/kotlin/com/airline/exception/BusinessException.kt
@@ -1,3 +1,7 @@
 package com.airline.exception
 
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
 class BusinessException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/airline/exception/NotFoundException.kt
+++ b/src/main/kotlin/com/airline/exception/NotFoundException.kt
@@ -1,3 +1,7 @@
 package com.airline.exception
 
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 class NotFoundException(message: String) : RuntimeException(message)


### PR DESCRIPTION
## Summary
- add BoletoDTO with validation and entity mappers
- implement `/boletos` REST controller for CRUD operations
- map custom exceptions to proper HTTP statuses

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68bf8f31a7cc832da92591a4e76d4196