### PR TITLE
Add JWT security with role-based authorization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,10 +30,13 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("io.jsonwebtoken:jjwt-api:0.12.5")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 
     // Oracle JDBC driver
     runtimeOnly("com.oracle.database.jdbc:ojdbc11")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
 
     // ✅ Swagger / OpenAPI para Spring Boot 3.x
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")

--- a/src/main/kotlin/com/airline/security/AuthController.kt
+++ b/src/main/kotlin/com/airline/security/AuthController.kt
@@ -1,0 +1,47 @@
+package com.airline.security
+
+import com.airline.usuario.Usuario
+import com.airline.usuario.UsuarioService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth")
+class AuthController(
+    private val authenticationManager: AuthenticationManager,
+    private val jwtService: JwtService,
+    private val usuarioService: UsuarioService,
+) {
+    @PostMapping("/login")
+    fun login(@RequestBody request: AuthRequest): ResponseEntity<AuthResponse> {
+        val authToken = UsernamePasswordAuthenticationToken(request.username, request.password)
+        authenticationManager.authenticate(authToken)
+        val user = usuarioService.findByUsername(request.username)
+        val token = jwtService.generateToken(user.username, user.rol)
+        return ResponseEntity.ok(AuthResponse(token))
+    }
+
+    @PostMapping("/register")
+    fun register(@RequestBody request: RegisterRequest): ResponseEntity<AuthResponse> {
+        val user = Usuario(
+            username = request.username,
+            passwordHash = request.password,
+            rol = request.rol,
+            empleado = null
+        )
+        val saved = usuarioService.create(user)
+        val token = jwtService.generateToken(saved.username, saved.rol)
+        return ResponseEntity.ok(AuthResponse(token))
+    }
+}
+
+data class AuthRequest(val username: String, val password: String)
+
+data class AuthResponse(val token: String)
+
+data class RegisterRequest(val username: String, val password: String, val rol: String)

--- a/src/main/kotlin/com/airline/security/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/airline/security/CustomUserDetailsService.kt
@@ -1,0 +1,21 @@
+package com.airline.security
+
+import com.airline.usuario.UsuarioRepository
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class CustomUserDetailsService(
+    private val usuarioRepository: UsuarioRepository,
+) : UserDetailsService {
+    override fun loadUserByUsername(username: String): UserDetails {
+        val usuario = usuarioRepository.findByUsername(username)
+            ?: throw UsernameNotFoundException("Usuario $username no encontrado")
+        val authorities = usuario.rol?.let { listOf(SimpleGrantedAuthority("ROLE_$it")) } ?: emptyList()
+        return User(usuario.username, usuario.passwordHash, authorities)
+    }
+}

--- a/src/main/kotlin/com/airline/security/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/airline/security/JwtAuthenticationFilter.kt
@@ -1,0 +1,39 @@
+package com.airline.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.stereotype.Component
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtService: JwtService,
+    private val userDetailsService: CustomUserDetailsService,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val authHeader = request.getHeader("Authorization")
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            val token = authHeader.substring(7)
+            val username = jwtService.extractUsername(token)
+            if (username != null && SecurityContextHolder.getContext().authentication == null) {
+                val userDetails = userDetailsService.loadUserByUsername(username)
+                if (jwtService.isTokenValid(token, userDetails.username)) {
+                    val authToken = UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.authorities
+                    )
+                    authToken.details = WebAuthenticationDetailsSource().buildDetails(request)
+                    SecurityContextHolder.getContext().authentication = authToken
+                }
+            }
+        }
+        filterChain.doFilter(request, response)
+    }
+}

--- a/src/main/kotlin/com/airline/security/JwtService.kt
+++ b/src/main/kotlin/com/airline/security/JwtService.kt
@@ -1,0 +1,48 @@
+package com.airline.security
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Service
+import java.util.Date
+import javax.crypto.SecretKey
+
+@Service
+class JwtService {
+    private val secretKey: SecretKey = Keys.hmacShaKeyFor("super-secret-key-which-is-long-enough-123456".toByteArray())
+    private val expirationMillis: Long = 1000 * 60 * 60 // 1 hour
+
+    fun generateToken(username: String, role: String?): String {
+        val claims = mutableMapOf<String, Any>()
+        role?.let { claims["role"] = it }
+        val now = Date()
+        return Jwts.builder()
+            .setClaims(claims)
+            .setSubject(username)
+            .setIssuedAt(now)
+            .setExpiration(Date(now.time + expirationMillis))
+            .signWith(secretKey, SignatureAlgorithm.HS256)
+            .compact()
+    }
+
+    fun extractUsername(token: String): String? = try {
+        Jwts.parser().verifyWith(secretKey).build()
+            .parseSignedClaims(token).payload.subject
+    } catch (ex: Exception) {
+        null
+    }
+
+    fun isTokenValid(token: String, username: String): Boolean {
+        val extracted = extractUsername(token)
+        return extracted == username && !isTokenExpired(token)
+    }
+
+    private fun isTokenExpired(token: String): Boolean = try {
+        val claims = Jwts.parser().verifyWith(secretKey).build()
+            .parseSignedClaims(token).payload
+        claims.expiration.before(Date())
+    } catch (ex: Exception) {
+        true
+    }
+}
+

--- a/src/main/kotlin/com/airline/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/airline/security/SecurityConfig.kt
@@ -1,0 +1,53 @@
+package com.airline.security
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.AuthenticationProvider
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+@EnableMethodSecurity
+class SecurityConfig(
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val userDetailsService: CustomUserDetailsService,
+) {
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests {
+                it.requestMatchers("/auth/login", "/auth/register").permitAll()
+                    .requestMatchers("/usuarios/**").hasRole("ADMIN")
+                    .anyRequest().authenticated()
+            }
+            .authenticationProvider(authenticationProvider())
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+        return http.build()
+    }
+
+    @Bean
+    fun authenticationProvider(): AuthenticationProvider {
+        val provider = DaoAuthenticationProvider()
+        provider.setUserDetailsService(userDetailsService)
+        provider.setPasswordEncoder(passwordEncoder())
+        return provider
+    }
+
+    @Bean
+    fun authenticationManager(config: AuthenticationConfiguration): AuthenticationManager =
+        config.authenticationManager
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+}

--- a/src/main/kotlin/com/airline/usuario/UsuarioRepository.kt
+++ b/src/main/kotlin/com/airline/usuario/UsuarioRepository.kt
@@ -2,4 +2,6 @@ package com.airline.usuario
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface UsuarioRepository : JpaRepository<Usuario, Long>
+interface UsuarioRepository : JpaRepository<Usuario, Long> {
+    fun findByUsername(username: String): Usuario?
+}

--- a/src/main/kotlin/com/airline/usuario/UsuarioService.kt
+++ b/src/main/kotlin/com/airline/usuario/UsuarioService.kt
@@ -1,22 +1,34 @@
 package com.airline.usuario
 
 import com.airline.exception.NotFoundException
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
 @Service
-class UsuarioService(private val usuarioRepository: UsuarioRepository) {
+class UsuarioService(
+    private val usuarioRepository: UsuarioRepository,
+    private val passwordEncoder: PasswordEncoder,
+) {
     fun findAll(): List<Usuario> = usuarioRepository.findAll()
 
     fun findById(id: Long): Usuario =
         usuarioRepository.findById(id).orElseThrow { NotFoundException("Usuario $id no encontrado") }
 
-    fun create(usuario: Usuario): Usuario = usuarioRepository.save(usuario)
+    fun findByUsername(username: String): Usuario =
+        usuarioRepository.findByUsername(username)
+            ?: throw NotFoundException("Usuario $username no encontrado")
+
+    fun create(usuario: Usuario): Usuario {
+        usuario.passwordHash = passwordEncoder.encode(usuario.passwordHash)
+        return usuarioRepository.save(usuario)
+    }
 
     fun update(id: Long, usuario: Usuario): Usuario {
         if (!usuarioRepository.existsById(id)) {
             throw NotFoundException("Usuario $id no encontrado")
         }
         usuario.id = id
+        usuario.passwordHash = passwordEncoder.encode(usuario.passwordHash)
         return usuarioRepository.save(usuario)
     }
 


### PR DESCRIPTION
## Summary
- add JWT utility and authentication filter to read `Authorization` tokens
- configure SecurityFilterChain with public login/register endpoints and protect others
- expose authentication endpoints and persist user roles for authorization

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68bf95f93f1c832d9b8028e5fb26bf89